### PR TITLE
Reimplement Underlining, and Fix Spoilers.

### DIFF
--- a/src/Eightdown.php
+++ b/src/Eightdown.php
@@ -5,6 +5,7 @@ use InfinityNext\Eightdown\Contracts\Eightdown as EightdownContract;
 use InfinityNext\Eightdown\Traits\ParsedownConfig;
 use InfinityNext\Eightdown\Traits\ParsedownExtensibility;
 use InfinityNext\Eightdown\Traits\ParsedownSpoilers;
+use InfinityNext\Eightdown\Traits\ParsedownUnderlineEmphasis;
 
 use InfinityNext\Eightdown\Parsedown as MarkdownEngine;
 
@@ -12,7 +13,8 @@ class Eightdown extends MarkdownEngine implements EightdownContract {
 	
 	use ParsedownConfig,
 		ParsedownExtensibility,
-		ParsedownSpoilers;
+		ParsedownSpoilers,
+		ParsedownUnderlineEmphasis;
 	
 	/**
 	 * Parses input text through our markup engine.

--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -1154,13 +1154,9 @@ class Parsedown
 
         $marker = $Excerpt['text'][0];
 
-        if ($Excerpt['text'][1] === $marker and preg_match($this->StrongRegex, $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] === $marker and preg_match($this->StrongRegex[$marker], $Excerpt['text'], $matches))
         {
             $emphasis = 'strong';
-        }
-        elseif ($Excerpt['text'][1] === $marker and preg_match($this->InsRegex, $Excerpt['text'], $matches))
-        {
-            $emphasis = 'ins';
         }
         elseif (preg_match($this->EmRegex[$marker], $Excerpt['text'], $matches))
         {
@@ -1556,9 +1552,10 @@ class Parsedown
         '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|',
     );
 
-    protected $StrongRegex = '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*[*])+?)[*]{2}(?![*])/s';
-
-    protected $InsRegex = '/^__((?:\\\\_|[^_]|_[^_]*_)+?)__(?!_)/us';
+    protected $StrongRegex = array(
+        '*' => '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*[*])+?)[*]{2}(?![*])/s',
+        '_' => '/^__((?:\\\\_|[^_]|_[^_]*_)+?)__(?!_)/us',
+    );
 
     protected $EmRegex = array(
         '*' => '/^[*]((?:\\\\\*|[^*]|[*][*][^*]+?[*][*])+?)[*](?![*])/s',

--- a/src/Traits/ParsedownExtensibility.php
+++ b/src/Traits/ParsedownExtensibility.php
@@ -90,6 +90,7 @@ trait ParsedownExtensibility {
 		if (!isset($this->InlineTypes[$Marker]))
 		{
 			$this->InlineTypes[$Marker] = [];
+			$this->inlineMarkerList .= $Marker;
 		}
 		
 		$InlineTypes = &$this->InlineTypes[$Marker];

--- a/src/Traits/ParsedownUnderlineEmphasis.php
+++ b/src/Traits/ParsedownUnderlineEmphasis.php
@@ -1,0 +1,46 @@
+<?php namespace InfinityNext\Eightdown\Traits;
+
+trait ParsedownUnderlineEmphasis {
+
+	protected function enableMarkupUnderlineEmphasis()
+        {
+                return $this->addInlineType("_", 'UnderlineEmphasis')
+                        ->addInlineType("*", 'UnderlineEmphasis')
+			->extendInline('UnderlineEmphasis', function ($Excerpt)
+                        {
+                            if ( ! isset($Excerpt['text'][1]))
+                            {
+                                return;
+                            }
+
+                            $marker = $Excerpt['text'][0];
+
+                            if (substr($Excerpt['text'], 0, 2) === "**" and preg_match($this->StrongRegex[$marker], $Excerpt['text'], $matches))
+                            {
+                                $emphasis = 'strong';
+                            }
+                            elseif (substr($Excerpt['text'], 0, 2) === "__" and preg_match($this->StrongRegex[$marker], $Excerpt['text'], $matches))
+                            {
+                                $emphasis = 'ins';
+                            }
+                            elseif (preg_match($this->EmRegex[$marker], $Excerpt['text'], $matches))
+                            {
+                                $emphasis = 'em';
+                            }
+                            else
+                            {
+                                return;
+                            }
+
+                            return array(
+                                'extent' => strlen($matches[0]),
+                                'element' => array(
+                                    'name' => $emphasis,
+                                    'handler' => 'line',
+                                    'text' => $matches[1],
+                                ),
+                            );
+			});
+        }
+
+}


### PR DESCRIPTION
Needs testing.

Spoilers were not enabled because they were missing from the
inlineMarkerList.

Revert changes to Parsedown.php

Put Underlining into a trait which we can use to override Emphasis. We
might want to add 'compatible markdown' as a board-level option at some
point.